### PR TITLE
Fixed regex for non-closed <link> tag

### DIFF
--- a/tasks/staticinline.js
+++ b/tasks/staticinline.js
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
   };
   
   var findReplaceLink = function(templatePath, content){
-    return content.replace(/<link.*href=['"]([^'"]+)['"].*inline=['"]true['"].*\/>/g, function(match, src){
+    return content.replace(/<link.*href=['"]([^'"]+)['"].*inline=['"]true['"].*\/?\s*>/g, function(match, src){
       return baseTAGReplace(templatePath, "style", src);
     });
   };


### PR DESCRIPTION
The closing of the <link> tag is optional in HTML (not XHTML).
