### PR TITLE
Regular expression activity in `baseTAGReplace` is unsafe

### DIFF
--- a/tasks/staticinline.js
+++ b/tasks/staticinline.js
@@ -25,9 +25,7 @@ module.exports = function(grunt) {
     var result = '';
     var srcPath = resolveFilePath(templatePath, src, basepath);
     if(srcPath){
-      result = '<TAG>CONTENT</TAG>'
-                 .replace(/CONTENT/g, grunt.file.read(srcPath).trim())
-                 .replace(/TAG/g, tag);
+      result = '<' + tag + '>' +  grunt.file.read(srcPath).trim() + '</' + tag + '>';
     }
     return result;
   };

--- a/test/expected/output-script.html
+++ b/test/expected/output-script.html
@@ -7,13 +7,23 @@
         console.log("This javascript module should be presented inline");
     }
     app();
-})();</script> 
+})();</script>
         <script>(function(){
     var commonShell = function(){
         console.log("common shell");
     };
     commonShell();
-})();</script> 
+})();</script>
+        <script>(function(){
+    var util = {
+        // Method extracted from RavenJS:
+        // https://github.com/getsentry/raven-js/blob/master/dist/raven.js
+        escapeRegExp: function (text) {
+            // This regexp should be presented inline.
+            return text.replace(/[\-\[\]{}()*+?.,\\\^$|#]/g, '\\$&');
+        }
+    };
+})();</script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />

--- a/test/fixtures/js/util.js
+++ b/test/fixtures/js/util.js
@@ -1,0 +1,10 @@
+(function(){
+    var util = {
+        // Method extracted from RavenJS:
+        // https://github.com/getsentry/raven-js/blob/master/dist/raven.js
+        escapeRegExp: function (text) {
+            // This regexp should be presented inline.
+            return text.replace(/[\-\[\]{}()*+?.,\\\^$|#]/g, '\\$&');
+        }
+    };
+})();

--- a/test/fixtures/template-script.html
+++ b/test/fixtures/template-script.html
@@ -2,8 +2,9 @@
     <head>
         <title>static inline</title>
         <link href="css/main.css" rel="stylesheet" />
-        <script src="js/app.js" inline="true"></script> 
-        <script src="js/common.js" inline="true"></script> 
+        <script src="js/app.js" inline="true"></script>
+        <script src="js/common.js" inline="true"></script>
+        <script src="js/util.js" inline="true"></script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />


### PR DESCRIPTION
We use `grunt-static-inline` to inline JS and CSS in our main application HTML document. Works well. Thank you much. :)

This afternoon I discovered our JavaScript file contents are being mutated by `baseTAGReplace()`. The issue is that `grunt.file.read(srcPath).trim()` may return a document which itself has RegExp tokens therein. The tokens are then replace and the file is mutated. Specifically we were inlining RavenJS and noticed the `escapeRegExp()` method changed.

Before:
```
function escapeRegExp(text) {
    return text.replace(/[\-\[\]{}()*+?.,\\\^$|#]/g, '\\$&');
}
```

After:
```
function escapeRegExp(text) {
    return text.replace(/[\-\[\]{}()*+?.,\\\^$|#]/g, '\\CONTENT');
}
```

Where `CONTENT` is the value of the `lastMatch` (`$&`) property. The problem should also exist for other RegExp properties.

The two commits below introduce a failing unit test and a subsequent code change to pass the unit test.