### PR TITLE
Refine attribute handling for script elements

### DIFF
--- a/tasks/staticinline.js
+++ b/tasks/staticinline.js
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
   };
 
   var findReplaceScript = function(templatePath, content, basepath){
-    return content.replace(/<script[^<]src=['"]([^'"]+)['"][^<]*inline=['"]true['"][^<]*\/?><\/script>/g, function(match, src){
+    return content.replace(/<script[^<]*src=['"]([^'"]+)['"][^<]*inline=['"]true['"][^<]*\/?><\/script>/g, function(match, src){
       return baseTAGReplace(templatePath, "script", src, basepath);
     });
   };

--- a/test/expected/output-script.html
+++ b/test/expected/output-script.html
@@ -24,8 +24,8 @@
         }
     };
 })();</script>
-        <script>(function(){ /* Any JS file */ })();</script>
-        <script data-attribute="present">(function(){ /* Any JS file */ })();</script>
+        <script text="text/javascript">(function(){ /* Any JS file */ })();</script>
+        <script data-attribute-a="a" data-attribute-b="b">(function(){ /* Any JS file */ })();</script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />

--- a/test/expected/output-script.html
+++ b/test/expected/output-script.html
@@ -25,6 +25,7 @@
     };
 })();</script>
         <script>(function(){ /* Any JS file */ })();</script>
+        <script data-attribute="present">(function(){ /* Any JS file */ })();</script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />

--- a/test/expected/output-script.html
+++ b/test/expected/output-script.html
@@ -24,6 +24,7 @@
         }
     };
 })();</script>
+        <script>(function(){ /* Any JS file */ })();</script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />

--- a/test/fixtures/js/vanilla.js
+++ b/test/fixtures/js/vanilla.js
@@ -1,0 +1,1 @@
+(function(){ /* Any JS file */ })();

--- a/test/fixtures/template-script.html
+++ b/test/fixtures/template-script.html
@@ -6,7 +6,7 @@
         <script src="js/common.js" inline="true"></script>
         <script src="js/util.js" inline="true"></script>
         <script text="text/javascript" src="js/vanilla.js" inline="true"></script>
-        <script src="js/vanilla.js" inline="true" data-attribute="present"></script>
+        <script src="js/vanilla.js" data-attribute-a="a" inline="true" data-attribute-b="b"></script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />

--- a/test/fixtures/template-script.html
+++ b/test/fixtures/template-script.html
@@ -6,6 +6,7 @@
         <script src="js/common.js" inline="true"></script>
         <script src="js/util.js" inline="true"></script>
         <script text="text/javascript" src="js/vanilla.js" inline="true"></script>
+        <script src="js/vanilla.js" inline="true" data-attribute="present"></script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />

--- a/test/fixtures/template-script.html
+++ b/test/fixtures/template-script.html
@@ -5,6 +5,7 @@
         <script src="js/app.js" inline="true"></script>
         <script src="js/common.js" inline="true"></script>
         <script src="js/util.js" inline="true"></script>
+        <script text="text/javascript" src="js/vanilla.js" inline="true"></script>
     </head>
     <body>
         <img src="imgs/MIT_Sloan.png" width="38" height="44" title="MIT Sloan" alt="MIT Sloan" />


### PR DESCRIPTION
Previously the existing `<script>` tags were replaced with attribute-less `<script>` tags. This works fine in many cases. Although we'd like to tag our `<script>` tags with data attributes.

There's a general use case to maintain `script` and `img` attributes as well as translating `link` attributes to `style` attributes. This PR only covers enough change to handle the `script` case.

* Fix: `src` no longer needs to be the first attribute in a `script` element
* New: Maintain attributes on `script` tags when inlining their file contents.

Thanks!