### PR TITLE
fix for minified XHTML

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,7 +62,8 @@ module.exports = function(grunt) {
         },
         files: {
           'tmp/output-full-xhtml.html': 'test/fixtures/template-full.xhtml',
-          'tmp/output-full-xhtml.xhtml': 'test/fixtures/template-full.xhtml'
+          'tmp/output-full-xhtml.xhtml': 'test/fixtures/template-full.xhtml',
+          'tmp/output-minified.xhtml': 'test/fixtures/template-minified.xhtml'
         }
       }
     },

--- a/tasks/staticinline.js
+++ b/tasks/staticinline.js
@@ -37,12 +37,12 @@ module.exports = function(grunt) {
   };
 
   var findReplaceScript = function(templatePath, content, basepath, addCDATA) {
-    return content.replace(/<script[^<]*src=['"]([^'"]+)['"][^<]*inline=['"]true['"][^<]*\/?><\/script>/g, function(match, src) {
+    return content.replace(/<script[^<]*src=['"]([^'"]+)['"][^<]*inline=['"]true['"][^<]*(\/>|><\/script>)/g, function(match, src) {
 
       // Remove attributes and closing `</script>`
       match = match.replace(/\s+src=['"]([^'"]+)['"]/, '')
                 .replace(/\s+inline=['"]true['"]/, '')
-                .replace(/<\/script>/, '');
+                .replace(/\s*\/>/, '>').replace(/<\/script>/, '');
 
       return match + readFile(templatePath, src, basepath, addCDATA) + '</script>';
     });
@@ -52,7 +52,7 @@ module.exports = function(grunt) {
     return content.replace(/<link[^<]*href=['"]([^'"]+)['"][^<]*inline=['"]true['"][^<]*\/?>/g, function(match, src) {
 
       // Remove attributes
-      match = match.replace(/<link/, '<style').replace(/\s+\/>/, '>')
+      match = match.replace(/<link/, '<style').replace(/\s*\/>/, '>')
                 .replace(/\s+href=['"]([^'"]+)['"]/, '')
                 .replace(/\s+rel=['"]stylesheet['"]/, '')
                 .replace(/\s+inline=['"]true['"]/, '');

--- a/test/expected/output-minified.xhtml
+++ b/test/expected/output-minified.xhtml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><title>static inline</title><style type="text/css">/*<![CDATA[*/h1{
+  color: #ff0000;
+  text-align: center;
+}
+
+img {
+  border: 1px solid red;
+}/*]]>*/</style><script type="text/javascript">/*<![CDATA[*/(function() {
+  var app = function() {
+    console.log("This javascript module should be inlined");
+  };
+  app();
+})();/*]]>*/</script></head><body></body></html>

--- a/test/fixtures/template-minified.xhtml
+++ b/test/fixtures/template-minified.xhtml
@@ -1,0 +1,1 @@
+@{DOCTYPE}@<html xmlns="http://www.w3.org/1999/xhtml"><head><title>static inline</title><link rel="stylesheet" href="css/main.css" type="text/css" inline="true"/><script src="js/app.js" type="text/javascript" inline="true"/></head><body></body></html>

--- a/test/staticinline_test.js
+++ b/test/staticinline_test.js
@@ -61,5 +61,12 @@ exports.staticinline = {
     var expected = readFile('test/expected/output-full.xhtml');
     test.equal(actual, expected, 'should replace all elements with inline attributes');
     test.done();
+  },
+
+  replaceMinifiedXHTML: function(test) {
+    var actual = readFile('tmp/output-minified.xhtml');
+    var expected = readFile('test/expected/output-minified.xhtml');
+    test.equal(actual, expected, 'should replace all elements with inline attributes');
+    test.done();
   }
 };


### PR DESCRIPTION
This pull requests inlines the files correctly for minified XHTML like this one:
```
<link rel="stylesheet" href="css/main.css" type="text/css" inline="true"/>
<script src="js/app.js" type="text/javascript" inline="true"/>
```