### PR TITLE
Fixed plugin when used with file object format

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -65,6 +65,24 @@ module.exports = function(grunt) {
           'tmp/output-full-xhtml.xhtml': 'test/fixtures/template-full.xhtml',
           'tmp/output-minified.xhtml': 'test/fixtures/template-minified.xhtml'
         }
+      },
+      main_multi: {
+        options: {
+          prefix: '@{',
+          suffix: '}@',
+          vars: {
+            'hello': 'Hello World',
+            'DOCTYPE': '<?xml version="1.0" encoding="utf-8" ?>\n<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">',
+            'partial_include': '<%= grunt.file.read("test/fixtures/partial.html") %>'
+          },
+          basepath: 'test/fixtures/'
+        },
+        files: [{
+          expand: true,
+          cwd: "test/fixtures",
+          src: "**/template-multi-*.html",
+          dest: "tmp"
+        }]
       }
     },
 

--- a/tasks/staticinline.js
+++ b/tasks/staticinline.js
@@ -14,9 +14,7 @@ module.exports = function(grunt) {
 
   var resolveFilePath = function(templatePath, src, basepath) {
     var srcPath;
-    if (!grunt.file.isPathAbsolute(src) && basepath) {
-      srcPath = path.resolve(basepath + src);
-    } else if (!grunt.file.isPathAbsolute(src)) {
+    if (!grunt.file.isPathAbsolute(src)) {
       srcPath = path.resolve(path.dirname(templatePath), src);
     } else if (grunt.file.isPathAbsolute(src) && basepath) {
       srcPath = path.resolve(basepath + src);
@@ -94,12 +92,12 @@ module.exports = function(grunt) {
     });
 
     this.files.forEach(function(f) {
-      var srcFile = f.src;
+      var srcFile = f.src[0];
       var destFile = f.dest;
       var content = grunt.file.read(srcFile);
       
       // add CDATA section for XML and XHTML files
-      var addCDATA = options.cdata || !!srcFile[0].match(/\.(xml|xhtml|xsd)$/i) || !!content.match(/(^<\?xml|<!DOCTYPE\s+html\s+PUBLIC\s+\"-\/\/W3C\/\/DTD\s+XHTML)/i);
+      var addCDATA = options.cdata || !!srcFile.match(/\.(xml|xhtml|xsd)$/i) || !!content.match(/(^<\?xml|<!DOCTYPE\s+html\s+PUBLIC\s+\"-\/\/W3C\/\/DTD\s+XHTML)/i);
       
       content = findAndReplace(options, srcFile, content, addCDATA);
       grunt.file.write(destFile, content);

--- a/test/expected/b/template-multi-b.html
+++ b/test/expected/b/template-multi-b.html
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+    <head>
+        <title>B</title>
+        <style>h1{
+  color: #ff0000;
+  text-align: center;
+}
+
+img {
+  border: 1px solid red;
+}</style>
+        <script text="text/javascript">(function(){ /* Any JS file */ })();</script>
+    </head>
+    <body>
+        B
+    </body>
+</html>

--- a/test/expected/template-multi-a.html
+++ b/test/expected/template-multi-a.html
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html>
+    <head>
+        <title>A</title>
+        <style>h1{
+  color: #ff0000;
+  text-align: center;
+}
+
+img {
+  border: 1px solid red;
+}</style>
+        <script text="text/javascript">(function(){ /* Any JS file */ })();</script>
+    </head>
+    <body>
+        A
+    </body>
+</html>

--- a/test/fixtures/b/template-multi-b.html
+++ b/test/fixtures/b/template-multi-b.html
@@ -1,0 +1,11 @@
+@{DOCTYPE}@
+<html>
+    <head>
+        <title>B</title>
+        <link href="/css/main.css" rel="stylesheet" inline="true">
+        <script text="text/javascript" src="../js/vanilla.js" inline="true"></script>
+    </head>
+    <body>
+        B
+    </body>
+</html>

--- a/test/fixtures/template-multi-a.html
+++ b/test/fixtures/template-multi-a.html
@@ -1,0 +1,11 @@
+@{DOCTYPE}@
+<html>
+    <head>
+        <title>A</title>
+        <link href="/css/main.css" rel="stylesheet" inline="true">
+        <script text="text/javascript" src="./js/vanilla.js" inline="true"></script>
+    </head>
+    <body>
+        A
+    </body>
+</html>

--- a/test/staticinline_test.js
+++ b/test/staticinline_test.js
@@ -68,5 +68,19 @@ exports.staticinline = {
     var expected = readFile('test/expected/output-minified.xhtml');
     test.equal(actual, expected, 'should replace all elements with inline attributes');
     test.done();
+  },
+
+  replaceMultiA: function(test) {
+    var actual = readFile('tmp/template-multi-a.html');
+    var expected = readFile('test/expected/template-multi-a.html');
+    test.equal(actual, expected, 'should deal with complex file structures');
+    test.done();
+  },
+
+  replaceMultiB: function(test) {
+    var actual = readFile('tmp/b/template-multi-b.html');
+    var expected = readFile('test/expected/b/template-multi-b.html');
+    test.equal(actual, expected, 'should deal with complex file structures');
+    test.done();
   }
 };


### PR DESCRIPTION
Similar to #9, this patch fixes errors caused by the usage of the file object format. More generally, it allows the plugin to be used with more complex file structures. The semantic of basepath was broken and had to be changed a little bit (see tests).